### PR TITLE
Setting Jeplu as library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.1.0)
 project(jeplu)
 set(CMAKE_BUILD_TYPE Debug)
 
+# Project extra definitions
+
 # Extra definitions
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -20,8 +22,7 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 set(JEPLU_INCLUDE "${PROJECT_SOURCE_DIR}/include/dlplugincreator.h"
                   "${PROJECT_SOURCE_DIR}/include/IPlugin.hpp"
                   "${PROJECT_SOURCE_DIR}/include/IPluginProxy.hpp"
-                  "${PROJECT_SOURCE_DIR}/include/IQtPlugin.hpp"
-                  "${PROJECT_SOURCE_DIR}/example/custom-proxy/QCustomProxy.hpp")
+                  "${PROJECT_SOURCE_DIR}/include/IQtPlugin.hpp")
 
 # Include src main CMakeLists
 add_subdirectory("${PROJECT_SOURCE_DIR}/src")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@
 include_directories("${PROJECT_SOURCE_DIR}/src")
 include_directories("${PROJECT_SOURCE_DIR}/src/core")
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Links the implementation of the interfaces ILibFinder or IPluginLoader
 # If the developer don't want Qt as dependecy or if the file structure should be other, just removeits implementation
 # and link with another created by its own. Create another ILibFinder/IPluginLoader, insert its CMakeList target name
@@ -15,11 +17,16 @@ foreach(comp ${COMPONENTS})
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/${comp}")
 endforeach()
 
-set(JEPLU_SOURCES "Jeplu.cpp"
-                  "../example/custom-proxy/QCustomProxy.cpp")
+set(JEPLU_SOURCES "Jeplu.cpp")
 
 # Build
-add_executable(${CMAKE_PROJECT_NAME} "${PROJECT_SOURCE_DIR}/main.cpp" ${JEPLU_SOURCES} ${JEPLU_INCLUDE})
+add_library(jeplu SHARED ${JEPLU_SOURCES} ${JEPLU_INCLUDE})
 
 # Links the library with components.
 target_link_libraries(jeplu ${COMPONENTS})
+
+set_target_properties(jeplu PROPERTIES PUBLIC_HEADER "${INCLUDE_STR}")
+
+# Install target to lib dir and its public headers to include dir.
+install(FILES ${JEPLU_INCLUDE} "Jeplu.hpp" DESTINATION "${PROJECT_BINARY_DIR}/include")
+install(TARGETS jeplu DESTINATION "${PROJECT_BINARY_DIR}/lib")

--- a/src/Jeplu.hpp
+++ b/src/Jeplu.hpp
@@ -2,7 +2,6 @@
 #define JEPLU_HPP
 
 #include "IPluginProxy.hpp"
-#include "PluginManager.hpp"
 
 /**
  *  \brief The Jeplu is the main class that works as a facade for dynamic libraries (plugins) management.
@@ -23,6 +22,11 @@ public:
      *  \brief Default constructor.
      */
     Jeplu();
+
+    /**
+     *  \brief Default destructor.
+     */
+    ~Jeplu();
 
     /**
      *  \brief Initializes the class loading all the plugin available in \c pluginsRootPath.
@@ -46,11 +50,15 @@ public:
     // template <typename T> std::vector<std::string> pluginsID() const {} //TODO
 
 private:
-    bool _initFactory();
+    /**
+     *  \brief Define the private implementation of jeplu as Pimpl.
+     */
+    class JepluImpl;
 
-    bool _initProxies();
-
-    std::unique_ptr<PluginManager> _manager;
+    /**
+     *  \brief Holds a unique pointer to the implementation Jeplu class.
+     */
+    std::unique_ptr<JepluImpl> _impl;
 };
 
 #endif // JEPLU_HPP

--- a/src/JepluLibFinder/JepluLibFinder.cpp
+++ b/src/JepluLibFinder/JepluLibFinder.cpp
@@ -29,7 +29,7 @@ void JepluLibFinder::_findLibsPath(const std::string &path)
     QDir pluginsDir(QString::fromStdString(path));
     for (QString pluginPath : pluginsDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot))
     {
-        // The lib should be named as path+libname+[osprefix lib][dirname].[so|dll|dylib]
+        // The lib should be named as path/libname/[osprefix lib]+libname.[so|dll|dylib]
         // unix example: example/libexample.[so|dylib]; Windows example: example/example.dll
         QString libPath = QString::fromStdString(path) + pluginPath +
                           (_hasLibPrefix ? "/lib" : "/") + pluginPath + _libSuffix;

--- a/src/loaders/CMakeLists.txt
+++ b/src/loaders/CMakeLists.txt
@@ -19,7 +19,6 @@ if (UNIX)
    list(APPEND LOADERS_LINK_LIBS ${CMAKE_DL_LIBS})
 endif (UNIX)
 
-
 # Build and link targets
 add_library(loaders ${LOADERS_SRC} ${INCLUDE_FILES})
 target_link_libraries(loaders ${LOADERS_LINK_LIBS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(jeplu-test)
+
+# Extra definitions
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include_directories("../example/")
+
+# Find Qt package
+find_package(Qt5 REQUIRED Core)
+
+# Find jeplu library
+find_library(JEPLU_LINK jeplu PATHS "${PROJECT_BINARY_DIR}/../lib" NO_DEFAULT_PATH)
+include_directories("${PROJECT_BINARY_DIR}/../include/")
+
+set(TEST_SOURCES  "main.cpp"
+                  "${PROJECT_BINARY_DIR}/../include/dlplugincreator.h"
+                  "${PROJECT_BINARY_DIR}/../include/IPlugin.hpp"
+                  "${PROJECT_BINARY_DIR}/../include/IPluginProxy.hpp"
+                  "${PROJECT_BINARY_DIR}/../include/IQtPlugin.hpp"
+                  "../example/custom-proxy/ICustomInterface.hpp"
+                  "../example/custom-proxy/QCustomProxy.cpp")
+
+# Build
+add_executable(jeplu-test ${TEST_SOURCES} ${JEPLU_INCLUDE})
+
+# Links the library with components.
+target_link_libraries(jeplu-test Qt5::Core ${JEPLU_LINK})

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3,8 +3,8 @@
 #include <string.h>
 #include <vector>
 
-#include "example/custom-proxy/ICustomInterface.hpp"
-#include "example/custom-proxy/QCustomProxy.hpp"
+#include "custom-proxy/ICustomInterface.hpp"
+#include "custom-proxy/QCustomProxy.hpp"
 #include "Jeplu.hpp"
 
 int main(int argc, const char **argv)


### PR DESCRIPTION
 - Creates a new executable called `jeplu-test`, that is also working.

    The `CMakeLists` of the executable is depending on 3 directories: `[build-dir]/../include`, 
    `[build-dir]/../lib`, which contains all the header files needed for `Jeplu` usage and the `Jeplu` 
    lib; and `../examples/`, which contains the examples of `IPlugin` and `IPluginProxy`. 
    That dependecy may continue until the real tests replace it.

 - For library creation, a Pimpl implementation was needed to the Jeplu class. See:
     * http://oliora.github.io/2015/12/29/pimpl-and-rule-of-zero.html
     * https://herbsutter.com/gotw/_100/